### PR TITLE
Fix useEffect dependency for unmount cleanup

### DIFF
--- a/client/src/components/ScratchpadCard.tsx
+++ b/client/src/components/ScratchpadCard.tsx
@@ -129,6 +129,10 @@ export default function ScratchpadCard() {
 
   // Autosave timeout ref
   const autoSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  
+  // Refs to capture latest title and content for cleanup
+  const titleRef = useRef(title);
+  const contentRef = useRef(content);
 
   // Update local state when currentNote changes
   useEffect(() => {
@@ -140,6 +144,12 @@ export default function ScratchpadCard() {
       setTitle('');
     }
   }, [currentNote]);
+
+  // Keep refs updated with latest values
+  useEffect(() => {
+    titleRef.current = title;
+    contentRef.current = content;
+  }, [title, content]);
 
   // Debounced autosave function
   const debouncedAutoSave = useCallback((title: string, content: string) => {
@@ -206,12 +216,12 @@ export default function ScratchpadCard() {
   // Save on component unmount
   useEffect(() => {
     return () => {
-      // Save when component unmounts
-      if (content.trim()) {
-        immediateSave(title, content);
+      // Save when component unmounts - use refs to get latest values
+      if (contentRef.current.trim()) {
+        immediateSave(titleRef.current, contentRef.current);
       }
     };
-  }, [title, content, immediateSave]);
+  }, [immediateSave]);
 
   const handleSave = async () => {
     if (!title.trim() && !content.trim()) return;


### PR DESCRIPTION
Refactor `ScratchpadCard` unmount effect to prevent excessive and stale data saves.

The `useEffect` hook intended for component unmount was incorrectly configured with `title` and `content` in its dependency array. This caused its cleanup function to run on every keystroke, triggering `immediateSave` with potentially stale data, leading to excessive API calls and a risk of overwriting recent changes with older content. This PR fixes this by removing `title` and `content` from the dependency array and using `useRef` to capture their latest values for the cleanup function, ensuring `immediateSave` is called only on unmount with current data.

---
<a href="https://cursor.com/background-agent?bcId=bc-61c3e49d-8d35-41c6-8d13-1b09db7f0f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61c3e49d-8d35-41c6-8d13-1b09db7f0f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

